### PR TITLE
feature/precommit ruff mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.12.2
     hooks:
       - id: ruff
         name: Ruff linter
@@ -9,7 +9,7 @@ repos:
         types: [python]
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         name: Mypy type checker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,22 @@
 repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        name: Ruff linter
+        entry: ruff check .
+        language: python
+        types: [python]
+        pass_filenames: false
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        name: Mypy type checker
+        language: python
+        types: [python]
+        pass_filenames: false
+        args: [eval_crypt]
   - repo: local
     hooks:
       - id: pytest

--- a/.taskmaster/tasks/task_009.txt
+++ b/.taskmaster/tasks/task_009.txt
@@ -497,7 +497,7 @@ def git_repo():
 Run the test suite with pytest to verify all functionality. Ensure tests cover all core functionality, edge cases, and error handling. Use code coverage tools to identify any untested code paths. Test on different operating systems (Windows, macOS, Linux) to ensure cross-platform compatibility.
 
 # Subtasks:
-## 1. Integrate key management into eval-crypt init [pending]
+## 1. Integrate key management into eval-crypt init [in-progress]
 ### Dependencies: None
 ### Description: Update the eval-crypt CLI 'init' command to generate and store a secret key if one does not exist. Ensure the key is created and saved securely during initialization, and is used by all encryption/decryption operations.
 ### Details:
@@ -506,4 +506,14 @@ Run the test suite with pytest to verify all functionality. Ensure tests cover a
 - Ensure the key is not overwritten if it already exists
 - Add or update tests to verify key creation during init
 - Document the key management behavior in the README if needed
+
+## 2. Add pre-commit hooks for ruff and mypy [pending]
+### Dependencies: None
+### Description: Set up pre-commit hooks to run ruff (linter) and mypy (type checker) on staged files. Add ruff and mypy to the test dependencies in pyproject.toml. Reinstall test dependencies and ensure both tools pass before opening a PR.
+### Details:
+- Add ruff and mypy to [project.optional-dependencies] test group in pyproject.toml
+- Add pre-commit hooks for ruff and mypy in .pre-commit-config.yaml
+- Reinstall test dependencies (pip install -e .[test])
+- Run ruff and mypy to ensure code passes linting and type checks
+- Only open a PR if both tools pass successfully
 

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -225,6 +225,15 @@
             "status": "in-progress",
             "dependencies": [],
             "parentTaskId": 9
+          },
+          {
+            "id": 2,
+            "title": "Add pre-commit hooks for ruff and mypy",
+            "description": "Set up pre-commit hooks to run ruff (linter) and mypy (type checker) on staged files. Add ruff and mypy to the test dependencies in pyproject.toml. Reinstall test dependencies and ensure both tools pass before opening a PR.",
+            "details": "- Add ruff and mypy to [project.optional-dependencies] test group in pyproject.toml\n- Add pre-commit hooks for ruff and mypy in .pre-commit-config.yaml\n- Reinstall test dependencies (pip install -e .[test])\n- Run ruff and mypy to ensure code passes linting and type checks\n- Only open a PR if both tools pass successfully",
+            "status": "in-progress",
+            "dependencies": [],
+            "parentTaskId": 9
           }
         ]
       },
@@ -252,7 +261,7 @@
     ],
     "metadata": {
       "created": "2025-07-10T10:23:51.578Z",
-      "updated": "2025-07-10T13:09:07.632Z",
+      "updated": "2025-07-10T13:21:23.827Z",
       "description": "Tasks for master context"
     }
   }

--- a/eval_crypt/crypto.py
+++ b/eval_crypt/crypto.py
@@ -1,4 +1,3 @@
-from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
 import os
 

--- a/eval_crypt/filters.py
+++ b/eval_crypt/filters.py
@@ -1,7 +1,6 @@
 from Crypto.Cipher import AES
 from base64 import b64encode, b64decode
 import json
-from typing import Optional
 
 def is_encrypted(content: bytes) -> bool:
     """Check if content is already in our encrypted format."""

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.11
+
+[mypy-click]
+ignore_missing_imports = true
+
+[mypy-Crypto.*]
+ignore_missing_imports = true 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ eval-crypt = "eval_crypt.cli:main"
 test = [
     "pytest",
     "pytest-click",
-    "pre-commit"
+    "pre-commit",
+    "ruff",
+    "mypy"
 ]
 
 [tool.setuptools]

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,26 @@
+import tempfile
+from pathlib import Path
+from eval_crypt.crypto import generate_key
+
+def test_generate_key_creates_file_and_returns_key():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = Path(tmpdir) / "test.key"
+        key = generate_key(str(key_path))
+        assert key_path.exists()
+        assert isinstance(key, bytes)
+        assert len(key) == 16
+        # Key file contents should match returned key
+        with open(key_path, "rb") as f:
+            file_key = f.read()
+        assert file_key == key
+
+def test_generate_key_idempotent():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = Path(tmpdir) / "test.key"
+        key1 = generate_key(str(key_path))
+        key2 = generate_key(str(key_path))
+        assert key1 == key2
+        # File should not be overwritten
+        with open(key_path, "rb") as f:
+            file_key = f.read()
+        assert file_key == key1 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+from click.testing import CliRunner
+from eval_crypt.cli import main
+from eval_crypt.crypto import generate_key, KEY_FILE
+from eval_crypt.filters import encrypt_content, decrypt_content
+
+SECRET_CONTENT = b"super secret data"
+
+
+def test_end_to_end_encryption_decryption(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Simulate a git repo
+        subprocess.run(["git", "init"], check=True)
+
+        # 1. Run eval-crypt init
+        result = runner.invoke(main, ["init"])
+        assert result.exit_code == 0
+        assert os.path.exists(".gitattributes")
+        assert os.path.exists(KEY_FILE)
+
+        # 2. Create two files
+        with open("secret1.txt", "wb") as f:
+            f.write(SECRET_CONTENT)
+        with open("secret2.txt", "wb") as f:
+            f.write(SECRET_CONTENT)
+
+        # 3. Add both files, then remove one
+        result = runner.invoke(main, ["add", "secret1.txt"])
+        assert result.exit_code == 0
+        result = runner.invoke(main, ["add", "secret2.txt"])
+        assert result.exit_code == 0
+        result = runner.invoke(main, ["remove", "secret2.txt"])
+        assert result.exit_code == 0
+
+        # 4. Check .gitattributes only lists secret1.txt
+        with open(".gitattributes", "r") as f:
+            lines = f.read().splitlines()
+        assert any("secret1.txt" in line for line in lines)
+        assert not any("secret2.txt" in line for line in lines)
+
+        # 5. Simulate commit: encrypt secret1.txt
+        key = generate_key()
+        with open("secret1.txt", "rb") as f:
+            plaintext = f.read()
+        encrypted = encrypt_content(plaintext, key)
+        with open("secret1.txt", "wb") as f:
+            f.write(encrypted)
+        # File should now be encrypted
+        with open("secret1.txt", "rb") as f:
+            encrypted_on_disk = f.read()
+        assert encrypted_on_disk != SECRET_CONTENT
+        # Should be decryptable
+        decrypted = decrypt_content(encrypted_on_disk, key)
+        assert decrypted == SECRET_CONTENT
+
+        # 6. Simulate merge/checkout: decrypt secret1.txt
+        with open("secret1.txt", "rb") as f:
+            encrypted = f.read()
+        decrypted = decrypt_content(encrypted, key)
+        with open("secret1.txt", "wb") as f:
+            f.write(decrypted)
+        # File should now be plaintext again
+        with open("secret1.txt", "rb") as f:
+            final_content = f.read()
+        assert final_content == SECRET_CONTENT 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,3 @@
-import pytest
 from eval_crypt import filters
 
 SECRET_KEY = b'0123456789abcdef'  # 16 bytes for AES-128

--- a/tests/test_gitattributes.py
+++ b/tests/test_gitattributes.py
@@ -1,0 +1,49 @@
+import pytest
+from eval_crypt.gitattributes import add_to_gitattributes, remove_from_gitattributes, list_gitattributes, GITATTRIBUTES_PATH
+
+@pytest.fixture(autouse=True)
+def clean_gitattributes():
+    if GITATTRIBUTES_PATH.exists():
+        GITATTRIBUTES_PATH.unlink()
+    yield
+    if GITATTRIBUTES_PATH.exists():
+        GITATTRIBUTES_PATH.unlink()
+
+def test_add_and_list_gitattributes():
+    GITATTRIBUTES_PATH.touch()
+    assert add_to_gitattributes('file1.txt') is True
+    assert add_to_gitattributes('file2.txt') is True
+    assert add_to_gitattributes('file1.txt') is False  # duplicate
+    managed = list_gitattributes()
+    assert managed is not None
+    assert 'file1.txt' in managed
+    assert 'file2.txt' in managed
+    assert len(managed) == 2
+
+def test_remove_gitattributes():
+    GITATTRIBUTES_PATH.touch()
+    add_to_gitattributes('file1.txt')
+    add_to_gitattributes('file2.txt')
+    assert remove_from_gitattributes('file1.txt') is True
+    assert remove_from_gitattributes('file1.txt') is False  # already removed
+    managed = list_gitattributes()
+    assert managed is not None
+    assert 'file1.txt' not in managed
+    assert 'file2.txt' in managed
+    assert remove_from_gitattributes('file2.txt') is True
+    managed = list_gitattributes()
+    assert managed is not None
+    assert managed == []
+
+def test_list_gitattributes_empty():
+    GITATTRIBUTES_PATH.touch()
+    managed = list_gitattributes()
+    assert managed is not None
+    assert managed == []
+
+def test_add_remove_without_gitattributes():
+    if GITATTRIBUTES_PATH.exists():
+        GITATTRIBUTES_PATH.unlink()
+    assert add_to_gitattributes('file.txt') is None
+    assert remove_from_gitattributes('file.txt') is None
+    assert list_gitattributes() is None 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,31 @@
+from eval_crypt.hooks import clean_filter, smudge_filter
+from eval_crypt.filters import encrypt_content, decrypt_content
+
+SECRET_KEY = b'0123456789abcdef'
+
+
+def test_clean_filter_encrypts():
+    plaintext = b"hook test data"
+    encrypted = clean_filter(plaintext, SECRET_KEY)
+    # Should be encrypted and decryptable
+    assert encrypted != plaintext
+    decrypted = decrypt_content(encrypted, SECRET_KEY)
+    assert decrypted == plaintext
+
+def test_smudge_filter_decrypts():
+    plaintext = b"hook test data"
+    encrypted = encrypt_content(plaintext, SECRET_KEY)
+    decrypted = smudge_filter(encrypted, SECRET_KEY)
+    assert decrypted == plaintext
+
+
+def test_clean_filter_idempotent():
+    plaintext = b"already encrypted"
+    encrypted = encrypt_content(plaintext, SECRET_KEY)
+    encrypted2 = clean_filter(encrypted, SECRET_KEY)
+    assert encrypted2 == encrypted
+
+def test_smudge_filter_on_plaintext():
+    plaintext = b"not encrypted"
+    decrypted = smudge_filter(plaintext, SECRET_KEY)
+    assert decrypted == plaintext 


### PR DESCRIPTION
- **feat: add module to manage .gitattributes for eval-crypt file tracking (add/remove/list patterns)**
- **tmp**
- **chore: commit user local changes**
- **rm**
- **test: add passing stub tests for CLI add/remove/list commands**
- **feat: gitattributes CLI logic, refactor, and pre-commit pytest hook**
- **refactor: remove file-based encryption/decryption logic, focus on in-memory filters for git integration**
- **feat(cli): integrate key management into init command and add tests**
- **chore: add ruff and mypy pre-commit hooks, per-module mypy ignores, and clean up pyproject.toml**
